### PR TITLE
ANA-12 allow multiple QtdShpExChrg in QtdShpType

### DIFF
--- a/DHL/Datatype/AM/QtdShpType.php
+++ b/DHL/Datatype/AM/QtdShpType.php
@@ -61,6 +61,8 @@ class QtdShpType extends Base
             'type' => 'QtdShpExChrgType',
             'required' => false,
             'subobject' => true,
+            'multivalues' => true,
+            'disableParentNode' => true,
         ), 
     );
 }


### PR DESCRIPTION
DHL API allows the following structure, this MR adds support for it to the code
```
            <QtdShp>
                <QtdShpExChrg>
                    <SpecialServiceType>OSINFO</SpecialServiceType>
                </QtdShpExChrg>
                <QtdShpExChrg>
                    <SpecialServiceType>TK</SpecialServiceType>
                </QtdShpExChrg>
            </QtdShp>
```